### PR TITLE
Fixed Vertex struct layout

### DIFF
--- a/Hypercube.Client/Graphics/Rendering/Renderer.Render.cs
+++ b/Hypercube.Client/Graphics/Rendering/Renderer.Render.cs
@@ -20,7 +20,6 @@ public sealed partial class Renderer
     private const int MaxBatchIndices = MaxBatchVertices * IndicesPerVertex;
     
     private readonly Vertex[] _batchVertices = new Vertex[MaxBatchVertices];
-    private readonly float[] _batchVerticesRaw = new float[MaxBatchVertices * Vertex.Size];
     private readonly uint[] _batchIndices = new uint[MaxBatchIndices];
     
     private uint _batchVertexIndex;
@@ -104,7 +103,7 @@ public sealed partial class Renderer
         _windowManager.WindowSwapBuffers(MainWindow);
     }
 
-    private void RenderEntities(ICamera camera)
+    public void Render()
     {
         
     }
@@ -112,24 +111,8 @@ public sealed partial class Renderer
     private void BatchUpdate()
     {
         _vao.Bind();
-        
-        BatchConvert();
-        
-        _vbo.SetData(_batchVerticesRaw);
+        _vbo.SetData(_batchVertices);
         _ebo.SetData(_batchIndices);
-    }
-    
-    private void BatchConvert()
-    {
-        var indexRaw = 0;
-        for (var i = 0; i < _batchVertexIndex; i++)
-        {
-            var vertex = _batchVertices[i];
-            foreach (var vertexValue in vertex.ToVertices())
-            {
-                _batchVerticesRaw[indexRaw++] = vertexValue;
-            }
-        }
     }
     
     private void BatchClear()
@@ -138,7 +121,6 @@ public sealed partial class Renderer
         _batchIndexIndex = 0;
         
         Array.Clear(_batchVertices, 0, _batchVertices.Length);
-        Array.Clear(_batchVerticesRaw, 0, _batchVerticesRaw.Length);
         Array.Clear(_batchIndices, 0, _batchIndices.Length);
     }
 }

--- a/Hypercube.Shared.Math/Vector/Vector3.cs
+++ b/Hypercube.Shared.Math/Vector/Vector3.cs
@@ -5,7 +5,7 @@ using Hypercube.Shared.Math.Extensions;
 namespace Hypercube.Shared.Math.Vector;
 
 [StructLayout(LayoutKind.Sequential)]
-public readonly partial struct Vector3(float x, float y, float z) : IEquatable<Vector3>
+public readonly partial struct Vector3 : IEquatable<Vector3>
 {
     public static readonly Vector3 Zero = new(0, 0, 0);
     public static readonly Vector3 One = new(1, 1, 1);
@@ -14,9 +14,9 @@ public readonly partial struct Vector3(float x, float y, float z) : IEquatable<V
     public static readonly Vector3 UnitY = new(0, 1, 0);
     public static readonly Vector3 UnitZ = new(0, 0, 1);
     
-    public readonly float X = x;
-    public readonly float Y = y;
-    public readonly float Z = z;
+    public readonly float X;
+    public readonly float Y;
+    public readonly float Z;
 
     public float LengthSquared
     {
@@ -36,6 +36,13 @@ public readonly partial struct Vector3(float x, float y, float z) : IEquatable<V
         get => this / Length;
     }
 
+    public Vector3(float x, float y, float z)
+    {
+        X = x;
+        Y = y;
+        Z = z;
+    }
+    
     public Vector3(float value) : this(value, value, value)
     {
     }
@@ -105,7 +112,7 @@ public readonly partial struct Vector3(float x, float y, float z) : IEquatable<V
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public override string ToString()
     {
-        return $"{x}, {y}, {z}";
+        return $"{X}, {Y}, {Z}";
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
Vector3 primary constructor `Vector3(float x, float y, float z)` affects the physical location of structure fields in memory. Which effectively prevents us, via pointers in OpenGL, from reading data directly. That's what caused the rendering bugs.
  